### PR TITLE
Remove deprecated property

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -22,12 +22,11 @@ class ScssLint(RubyLinter):
 
     """Provides an interface to the scss-lint executable."""
 
-    syntax = ('css', 'sass', 'scss')
     cmd = ('ruby', '-S', 'scss-lint', '${args}', '${file}')
     regex = r'^.+?:(?P<line>\d+)(?::(?P<col>\d+))? (?:(?P<error>\[E\])|(?P<warning>\[W\])) (?P<message>[^`]*(?:`(?P<near>.+?)`)?.*)'
     word_re = r'[^\s]+[\w]'
     defaults = {
-
+        'selector': 'source.css - meta.attribute-with-value, source.sass, source.scss'
     }
 
     def reposition_match(self, line, col, m, vv):


### PR DESCRIPTION
The `syntax` property is deprecated in favor of the `defaults:{'selector'}` property. [Source reference](http://www.sublimelinter.com/en/stable/linter_settings.html#selector)