### PR TITLE
Fix errors in SublimeLinter 4.12

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -22,12 +22,11 @@ class ScssLint(RubyLinter):
 
     """Provides an interface to the scss-lint executable."""
 
-    syntax = ('css', 'sass', 'scss')
     cmd = ('ruby', '-S', 'scss-lint', '${args}', '${file}')
     regex = r'^.+?:(?P<line>\d+)(?::(?P<col>\d+))? (?:(?P<error>\[E\])|(?P<warning>\[W\])) (?P<message>[^`]*(?:`(?P<near>.+?)`)?.*)'
     word_re = r'[^\s]+[\w]'
     defaults = {
-
+      'selector': 'source.scss'
     }
 
     def reposition_match(self, line, col, m, vv):


### PR DESCRIPTION
Upgrading Sublime Linter to 4.12 causes errors due to use of deprecated variables in SublimeLinter-scss-lint:

```
SublimeLinter: ERROR:
=====================
scsslint: Defining 'cls.syntax' has no effect anymore. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector instead.

SublimeLinter: ERROR:
=====================
scsslint disabled. 'selector' is mandatory in 'cls.defaults'.
 See http://www.sublimelinter.com/en/stable/linter_settings.html#selector
```

This pull request fixes those errors and restores functionality.

Sublime Linter 4.12 changelog:
```
- Deprecations:
    We've previously pushed a number of deprecation warnings,
    those deprecations are now in full effect. Some new warnings
    (mostly for features you shouldn't be using anyway) have been
    added. Background info for plugin developers can be found
    here: https://github.com/SublimeLinter/SublimeLinter/pull/1613
    and:  https://github.com/SublimeLinter/SublimeLinter/milestone/7?closed=1
```
https://github.com/SublimeLinter/SublimeLinter/blob/master/messages/4.12.0.txt